### PR TITLE
chore(ci): restrict semgrep workflow permissions to only read contents

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/flask-demo/security/code-scanning/1](https://github.com/openfga/flask-demo/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the Semgrep job only needs to read repository contents, set `contents: read` as the minimal required permission. This can be done either at the workflow root (applies to all jobs) or at the job level (applies only to the `semgrep` job). The best practice is to add it at the job level for clarity and future extensibility. Edit the `.github/workflows/semgrep.yaml` file, and add the following under the `semgrep` job (after `name: Scan` and before `runs-on: ubuntu-latest`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
